### PR TITLE
Add aarch64/arm64 Flags

### DIFF
--- a/native/rust_ot/.cargo/config
+++ b/native/rust_ot/.cargo/config
@@ -3,3 +3,9 @@ rustflags = [
     "-C", "link-arg=-undefined",
     "-C", "link-arg=dynamic_lookup",
 ]
+
+[target.aarch64-apple-darwin]
+rustflags = [
+    "-C", "link-arg=-undefined",
+    "-C", "link-arg=dynamic_lookup",
+]


### PR DESCRIPTION
This PR adds linker flags for rust when running on `aarch64-apple-darwin` systems. These flags match the custom flags already used by `x86_64-apple-darwin`.